### PR TITLE
compatibility with gcc 9.4 under Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@
 CC=gcc
 
 CFLAGS=-c -g -pipe -Wall -Wextra -std=c11
-LDFLAGS=-lm
+LDLIBS=-lm
 
 SOURCES=$(wildcard *.c)
 OBJECTS=$(SOURCES:.c=.o)
 EXECUTABLE=ccg
 
 all: $(SOURCES) $(EXECUTABLE)
-	
+
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+	$(CC) $(OBJECTS) $(LDLIBS) -o $@
 
 .c.o:
 	$(CC) $(CFLAGS) $< -o $@

--- a/expression.c
+++ b/expression.c
@@ -88,7 +88,7 @@ Expression *makeExpression(Context *context, unsigned nesting)
     return expression;
 }
 
-static void buildOperand(Expression *expression, Context *context, unsigned /* nesting */)
+static void buildOperand(Expression *expression, Context *context, unsigned nesting)
 {
     expression->expr.operand = selectOperand(context);
 }

--- a/statement.c
+++ b/statement.c
@@ -140,7 +140,7 @@ static void buildFunctionCall(Statement *statement, Context *context, unsigned n
     statement->stmnt.funccallstatement = funccallstatement;
 }
 
-static void buildAssignment(Statement *statement, Context *context, unsigned /* nesting */)
+static void buildAssignment(Statement *statement, Context *context, unsigned nesting)
 {
     AssignmentStatement *as = xmalloc(sizeof(*as));
 
@@ -153,7 +153,7 @@ static void buildAssignment(Statement *statement, Context *context, unsigned /* 
 
 #define PTRASSIGNMENT_IS_CONSISTENT(lhs, rhs) (INTEGERTYPE_SIZE(ultimateType(lhs)) <= INTEGERTYPE_SIZE(ultimateType(rhs)))
 
-static void buildPtrAssignment(Statement *statement, Context *context, unsigned /* nesting */)
+static void buildPtrAssignment(Statement *statement, Context *context, unsigned nesting)
 {
     Variable *v;
     PtrAssignmentStatement *pas = xmalloc(sizeof(*pas));
@@ -169,7 +169,7 @@ static void buildPtrAssignment(Statement *statement, Context *context, unsigned 
     statement->stmnt.ptrassignmentstatement = pas;
 }
 
-static void buildReturn(Statement *statement, Context *context, unsigned /* nesting */)
+static void buildReturn(Statement *statement, Context *context, unsigned nesting)
 {
     ReturnStatement *rs = xmalloc(sizeof(*rs));
 
@@ -178,7 +178,7 @@ static void buildReturn(Statement *statement, Context *context, unsigned /* nest
     statement->stmnt.returnstatement = rs;
 }
 
-static void buildGoto(Statement *statement, Context *context, unsigned /* nesting */)
+static void buildGoto(Statement *statement, Context *context, unsigned nesting)
 {
     GotoStatement *gs = xmalloc(sizeof(*gs));
 


### PR DESCRIPTION
There were minor issues preventing compilation with gcc 9.4 under Linux.

1. The syntax of just specifying a type and not a parameter name is not accepted for specifying an unused parameter.
2. Libraries must be specified after object files.