### PR TITLE
Monniaux

### DIFF
--- a/commandline.c
+++ b/commandline.c
@@ -41,6 +41,7 @@ static void printHelp(void)
     puts("  --max-block-nesting\t\tControl the nesting of the blocks (default 7)");
     puts("  --max-pointer-depth\t\tMaximum depth of a pointer (default 2)");
     puts("  --no-jumps\t\t\tDisables jumps (enabled by default)");
+    puts("  --no-omitted-operand-conditional\tDisable x ? : z conditionals without second operand");
     exit(EXIT_SUCCESS);
 }
 

--- a/commandline.c
+++ b/commandline.c
@@ -68,11 +68,13 @@ static void setopt(int index)
 
     if(index >= 0 && index < 9)
         *(index2member[index]) = strtol(optarg, NULL, 10);
-    else if(index == 9)
-        cmdline.nojumps = true;
+    else if (index == 9)
+        cmdline.no_omitted_operand_conditional = true;
     else if(index == 10)
-        printHelp();
+        cmdline.nojumps = true;
     else if(index == 11)
+        printHelp();
+    else if(index == 12)
         printVersion();
 
     /* Sanity check */
@@ -95,6 +97,7 @@ void processCommandline(int argc, char **argv)
         {"max-expression-nesting", required_argument, NULL, 0},
         {"max-block-nesting", required_argument, NULL, 0},
         {"max-pointer-depth", required_argument, NULL, 0},
+	{"no-omitted-operand-conditional", no_argument, NULL, 0},
         {"no-jumps", no_argument, NULL, 0},
         {"help", no_argument, NULL, 0},
         {"version", no_argument, NULL, 0},

--- a/expression.c
+++ b/expression.c
@@ -109,7 +109,7 @@ static void buildTernary(Expression *expression, Context *context, unsigned nest
     struct TernaryExpression *te = xmalloc(sizeof(*te));
 
     te->test = makeExpression(context, nesting + 1);
-    te->truepath = (rand() % 5) ? makeExpression(context, nesting + 1) : NULL;
+    te->truepath = (cmdline.no_omitted_operand_conditional || rand() % 5) ? makeExpression(context, nesting + 1) : NULL;
     te->falsepath = makeExpression(context, nesting + 1);
     expression->expr.ternexpr = te;
 }

--- a/types.h
+++ b/types.h
@@ -270,4 +270,5 @@ typedef struct
     unsigned seed, max_functions, max_localvars, max_function_parameters, min_statements_per_block, max_statements_per_block,
     max_expression_nesting, max_block_nesting, max_pointer_depth;
     bool nojumps;
+    bool no_omitted_operand_conditional;
 } CommandlineOpt;


### PR DESCRIPTION
--no-omitted-operand-conditional (disable gcc extension producing x ? : y : z statements)